### PR TITLE
Feature / Implementation parity between WinBatch, DosBatch and ExecWith

### DIFF
--- a/opsi-script/opsiscript.lpi
+++ b/opsi-script/opsiscript.lpi
@@ -68,8 +68,7 @@
             <CompilerMessages>
               <IgnoredMessages idx5058="True" idx5027="True"/>
             </CompilerMessages>
-            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSDEBUG
--dSYNAPSE"/>
+            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSDEBUG -dSYNAPSE"/>
           </Other>
         </CompilerOptions>
       </Item2>
@@ -112,8 +111,7 @@
             <CompilerMessages>
               <IgnoredMessages idx5058="True" idx5027="True"/>
             </CompilerMessages>
-            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI
--dSYNAPSE"/>
+            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dSYNAPSE"/>
           </Other>
         </CompilerOptions>
       </Item3>
@@ -346,7 +344,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
-      <OtherUnitFiles Value="..\common;..\external_libraries\dcpcrypt\Ciphers;..\external_libraries\dcpcrypt\Hashes;..\external_libraries\synapse40lib;..\external_libraries\misc;..\external_libraries\uSMBIOS;..\external_libraries\dcpcrypt;..\external_libraries\indy\Lib\System;..\external_libraries\indy\Lib\Core;..\external_libraries\indy\Lib\Protocols;..\external_libraries\indy\Lib"/>
+      <OtherUnitFiles Value="..\common;..\external_libraries\dcpcrypt\Ciphers;..\external_libraries\dcpcrypt\Hashes;..\external_libraries\synapse;..\external_libraries\misc;..\external_libraries\uSMBIOS;..\external_libraries\dcpcrypt;..\external_libraries\indy\Lib\System;..\external_libraries\indy\Lib\Core;..\external_libraries\indy\Lib\Protocols;..\external_libraries\indy\Lib"/>
     </SearchPaths>
     <Parsing>
       <SyntaxOptions>
@@ -376,8 +374,7 @@
       <CompilerMessages>
         <IgnoredMessages idx5058="True" idx5027="True"/>
       </CompilerMessages>
-      <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSLOG
--dSYNAPSE"/>
+      <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSLOG -dSYNAPSE"/>
     </Other>
   </CompilerOptions>
   <Debugging>

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -25,10 +25,13 @@ interface
 
 uses
 {$IFDEF WINDOWS}
-  //jwawinnt,
   JwaWinType,
   jwatlhelp32,
   jwawinbase,
+  JwaSddl,
+  JwaWinNT,
+  jwaAclApi,
+  JwaAccCtrl,
   JwaProfInfo,
   JwaUserEnv,
   //JclMiscel,
@@ -460,6 +463,10 @@ function GetNetDrive(const pathname: string): string;
 {$IFNDEF WIN64}
 function KillTask(ExeFileName: string; var info: string): boolean;
 {$ENDIF WIN64}
+
+{$IFDEF WINDOWS}
+function SetFilePermissionForRunAs(filename: string; runas: TRunAs; var errorCode: DWORD): boolean;
+{$ENDIF WINDOWS}
 
 function StartProcess(CmdLinePasStr: string; ShowWindowFlag: integer;
   WaitForReturn: boolean; WaitForWindowVanished: boolean;
@@ -1447,6 +1454,191 @@ end;
 
 {$ENDIF WINDOWS}
 
+{$IFDEF WINDOWS}
+function SetFilePermissionForRunAs(filename: string; runas: TRunAs; var errorCode: DWORD): boolean;
+
+const
+  CHANGED_SECURITY_INFO = jwawinnt.DACL_SECURITY_INFORMATION;
+  EA_COUNT = 1;
+
+// workaround for a FPC bug, see:
+// https://stackoverflow.com/a/59172446/12403540
+// https://bugs.freepascal.org/view.php?id=36368
+type
+  TRUSTEE_FIX = packed record
+    pMultipleTrustee: Pointer;
+    MultipleTrusteeOperation: DWORD;
+    TrusteeForm: DWORD;
+    TrusteeType: DWORD;
+    ptstrName: LPSTR;
+  end;
+
+  EXPLICIT_ACCESS_FIX = packed record
+    grfAccessPermissions: DWORD;
+    grfAccessMode: DWORD;
+    grfInheritance: DWORD;
+    Trustee: TRUSTEE_FIX;
+  end;
+
+var
+  sid: JwaWinNT.PSID;
+  sidSize: DWORD;
+  nameUse: JwaWinNT.SID_NAME_USE;
+  refDomain: LpStr;
+  refDomainSize: DWORD;
+  dolocalfree: boolean;
+  procToken: HANDLE;
+  ea: Array[0..(EA_COUNT-1)] of EXPLICIT_ACCESS_FIX;
+  acl: jwawinnt.PACL;
+  status: jwawintype.DWORD;
+
+  function SetPrivilege(token: HANDLE; privilege: PChar; state: boolean): boolean;
+  var
+    luid: jwawintype._LUID;
+    tp: jwawinnt.TOKEN_PRIVILEGES;
+  begin
+    if not jwawinbase.LookupPrivilegeValue(nil, privilege, luid) then
+      Result := false
+    else
+    begin
+      FillChar(tp, sizeOf(tp), #0);
+      tp.privilegeCount := 1;
+      tp.Privileges[0].Luid := luid;
+      if state then
+        tp.Privileges[0].Attributes := SE_PRIVILEGE_ENABLED
+      else
+        tp.Privileges[0].Attributes := SE_PRIVILEGE_REMOVED;
+
+        Result := AdjustTokenPrivileges(token, LongBool(false), @tp, sizeOf(tp), nil,nil);
+    end
+  end;
+
+begin
+  if runas = traInvoker then
+    Result := true
+  else
+    try
+      begin
+        status := NO_ERROR;
+        sidSize := 0;
+        refDomainSize := 0;
+        doLocalFree := false;
+
+        procToken := INVALID_HANDLE_VALUE;
+
+        sid := nil;
+
+        // Determine the SID of the user that the file will be run as
+
+        if runas = traLoggedOnUser then
+        begin
+          // use usercontextSID variable to determine SID of logged on user
+          Result := jwasddl.ConvertStringSidToSidA(PChar(usercontextSID), sid);
+          dolocalfree := true;
+        end
+        else if runas = traPcpatch then
+        begin
+          // not really relevant, as it is never used in opsi script
+          jwawinbase.LookupAccountNameA(nil, 'pcpatch', nil,
+            sidSize, nil, refDomainSize, nameUse);
+
+          GetMem(sid, sidSize);
+          GetMem(refDomain, refDomainSize);
+
+          Result := jwawinbase.LookupAccountNameA(nil, 'pcpatch',
+            sid, sidSize, refDomain, refDomainSize, nameUse);
+        end
+        else if runas in [traAdmin, traAdminProfile, traAdminProfileExplorer,
+          traAdminProfileImpersonate, traAdminProfileImpersonateExplorer] then
+        begin
+          // to get the user's SID we need to create the local admin already here
+          Result := CreateTemporaryLocalAdmin(runas);
+
+          if Result then
+          begin
+            jwawinbase.LookupAccountNameA(nil, 'opsiSetupAdmin', nil, sidSize, nil, refDomainSize, nameUse);
+            GetMem(sid, sidSize);
+            GetMem(refDomain, refDomainSize);
+
+            Result := jwawinbase.LookupAccountNameA(nil, 'opsiSetupAdmin',
+              sid, sidSize, refDomain, refDomainSize, nameUse);
+          end
+        end
+        else
+          Result := false;
+
+        // Create an ACL allowing the determined SID
+        // Read and Execute Rights, then apply it to
+        // the given file.
+
+        if Result then
+        begin
+          jwawinbase.ZeroMemory(@ea, EA_COUNT * sizeOf(EXPLICIT_ACCESS_FIX));
+
+          ea[0].grfAccessPermissions := FILE_GENERIC_READ or FILE_GENERIC_EXECUTE;
+          ea[0].grfAccessMode := DWORD(SET_ACCESS);
+          ea[0].grfInheritance := NO_INHERITANCE;
+          ea[0].Trustee.MultipleTrusteeOperation := DWORD(NO_MULTIPLE_TRUSTEE);
+          ea[0].Trustee.pMultipleTrustee := nil;
+          ea[0].Trustee.TrusteeForm := DWORD(TRUSTEE_IS_SID);
+          ea[0].Trustee.TrusteeType := DWORD(TRUSTEE_IS_USER);
+          ea[0].Trustee.ptstrName := pointer(sid);
+
+          status := jwaaclapi.SetEntriesInAclA(EA_COUNT, @ea, nil, acl);
+
+          if status <> ERROR_SUCCESS then
+          begin
+            Result := false;
+          end
+          else
+          begin
+            status := jwaaclapi.SetNamedSecurityInfoA(PChar(filename),
+              JwaAccCtrl.SE_FILE_OBJECT, CHANGED_SECURITY_INFO, nil, nil, acl, nil);
+
+            if status <> ERROR_SUCCESS then
+            begin
+              // if it fails we are probably missing the SE_RESTORE_NAME privilege, so we retry
+              status := NO_ERROR;
+
+              if (not OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, procToken)) or
+                 (not SetPrivilege(procToken, SE_RESTORE_NAME, true)) then
+                Result := false
+              else
+              begin
+                status := jwaaclapi.SetNamedSecurityInfoA(PChar(filename),
+                  JwaAccCtrl.SE_FILE_OBJECT, CHANGED_SECURITY_INFO, nil, nil, nil, nil);
+                Result := (status = ERROR_SUCCESS);
+
+                if not SetPrivilege(procToken, SE_RESTORE_NAME, false) then
+                  LogDatei.log('Could not disable SE_RESTORE_NAME privilege: ' + IntToStr(getLastError()), LLDebug);
+              end;
+            end;
+          end;
+        end;
+      end
+    finally
+      begin
+        if not Result and (status = NO_ERROR) then
+          status := getLastError();
+
+        errorCode := status;
+
+        if Assigned(sid) then
+          if doLocalFree then
+            LocalFree(DWORD(sid))
+          else
+            FreeMem(sid, sidSize);
+
+        if Assigned(refDomain) then
+          FreeMem(refDomain, refDomainSize);
+
+        if Assigned(acl) then
+          LocalFree(DWORD(acl));
+      end;
+    end;
+end;
+
+{$ENDIF WINDOWS}
 
 {$IFDEF WINDOWS}
 function StartProcess_se(CmdLinePasStr: string; ShowWindowFlag: integer;

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -1540,7 +1540,7 @@ begin
         end
         else if runas = traPcpatch then
         begin
-          // not really relevant, as it is never used in opsi script
+          {
           jwawinbase.LookupAccountNameA(nil, 'pcpatch', nil,
             sidSize, nil, refDomainSize, nameUse);
 
@@ -1549,6 +1549,11 @@ begin
 
           Result := jwawinbase.LookupAccountNameA(nil, 'pcpatch',
             sid, sidSize, refDomain, refDomainSize, nameUse);
+          }
+
+          // just generate an error, as it is currently unused anyways
+          LogDatei.log('SetFilePermissionForRunAs: traPcpatch is not supported', LLError);
+          Result := false;
         end
         else if runas in [traAdmin, traAdminProfile, traAdminProfileExplorer,
           traAdminProfileImpersonate, traAdminProfileImpersonateExplorer] then

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2786,6 +2786,7 @@ begin
   //logdatei.DependentAdd('>->->'+filename+'='+getExecutableName(filename),LLEssential);
   try
     try
+      FillChar(sa, SizeOf(sa), 0);
       sa.nLength := sizeof(sa);
       sa.lpSecurityDescriptor := nil;
       sa.bInheritHandle := True;
@@ -3203,6 +3204,7 @@ begin
   //logdatei.DependentAdd('>->->'+filename+'='+getExecutableName(filename),LLEssential);
   try
     try
+      FillChar(sa, SizeOf(sa), 0);
       sa.nLength := sizeof(sa);
       sa.lpSecurityDescriptor := nil;
       sa.bInheritHandle := True;
@@ -3747,6 +3749,7 @@ begin
               begin
 *)
       // Step 4: set the startup info for the new process
+      FillChar(sa, SizeOf(sa), 0);
       sa.nLength := sizeof(sa);
       sa.lpSecurityDescriptor := nil;
       sa.bInheritHandle := True;

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2679,6 +2679,10 @@ begin
           repeat
             n := ReadStream(Buffer, FPCProcess, output, showoutput);
           until n <= 0;
+
+          // add remainder of buffer as last line
+          if Buffer <> '' then
+             output.Add(Buffer);
         end;
 
         ProcessMess;
@@ -3138,6 +3142,10 @@ begin
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
           until (BytesRead <= 0) or (not readResult);
 
+          // add remainder of buffer as last line
+          if Buffer <> '' then
+            output.Add(Buffer);
+
           ProcessMess;
 
           GetExitCodeProcess(ProcessInfo.hProcess, lpExitCode);
@@ -3537,6 +3545,10 @@ begin
           until (BytesRead <= 0) or (not readResult);
 
           ProcessMess;
+
+          // add remainder of buffer as last line
+          if Buffer <> '' then
+            output.Add(Buffer);
 
           //exitCode := FpcProcess.ExitStatus;
           GetExitCodeProcess(ProcessInfo.hProcess, lpExitCode);
@@ -4074,6 +4086,10 @@ begin
             if not readResult then
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
           until (BytesRead <= 0) or (not readResult);
+
+          // add remainder of buffer as last line
+          if Buffer <> '' then
+            output.Add(Buffer);
 
           ProcessMess;
           GetExitCodeProcess(processInfo.hProcess, lpExitCode);

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -125,6 +125,8 @@ type
     traAdminProfileImpersonate, traAdminProfileImpersonateExplorer, traLoggedOnUser);
 {$ENDIF}
 
+  TShowOutputFlag = (tsofHideOutput, tsofShowOutput, tsofShowOutputNoSystemInfo);
+
 
 
 (*
@@ -478,7 +480,7 @@ function StartProcess(CmdLinePasStr: string; ShowWindowFlag: integer;
   var Report: string; var ExitCode: longint): boolean; overload;
 
 function StartProcess(CmdLinePasStr: string; ShowWindowFlag: integer;
-  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
+  showoutputflag: TShowOutputFlag; WaitForReturn: boolean; WaitForWindowVanished: boolean;
   WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; RunAs: TRunas; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output: TXStringList): boolean; overload;
@@ -4131,7 +4133,7 @@ begin
   // provide a temp stringlist
   output := TXStringList.create;
 
-  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, false, WaitForReturn,
+  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, tsofHideOutput, WaitForReturn,
     WaitForWindowVanished, WaitForWindowAppearing, WaitForProcessEnding,
     False, runAs, Ident, WaitSecs, Report, ExitCode, output);
 
@@ -4149,16 +4151,16 @@ begin
   // compatibility with old version that had no output capturing
   output := TXStringList.create;
 
-  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, false, WaitForReturn, WaitForWindowVanished,
-    WaitForWindowAppearing, WaitForProcessEnding, waitsecsAsTimeout, RunAs, Ident,
-    WaitSecs, Report, Exitcode, output);
+  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, tsofHideOutput, WaitForReturn,
+    WaitForWindowVanished, WaitForWindowAppearing, WaitForProcessEnding,
+    waitsecsAsTimeout, RunAs, Ident, WaitSecs, Report, Exitcode, output);
 
   output.free;
 end;
 
 function StartProcess(CmdLinePasStr: string; ShowWindowFlag: integer;
-  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
-  WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
+  showoutputflag: TShowOutputFlag; WaitForReturn: boolean;
+  WaitForWindowVanished: boolean; WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; RunAs: TRunAs; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output : TXStringList): boolean;
 
@@ -4199,6 +4201,7 @@ var
   myduptoken, mytoken: THandle;
   {$ENDIF WIN32}
 
+  showoutput: boolean;
 const
   secsPerDay = 86400;
   ReadBufferSize = 2048;
@@ -4233,23 +4236,44 @@ begin
     end;
   end;
 
-  {$IFDEF GUI}
+  showoutput := false;
+
   if not WaitForReturn then
-    showoutput := false;
+    showoutputflag := tsofHideOutput;
+
+  if showoutputFlag in [tsofShowOutput, tsofShowOutputNoSystemInfo] then
+    showoutput := true;
+
+  {$IFDEF GUI}
+
 
   if showoutput then
   begin
     FBatchOberflaeche.Left:= 5;
     FBatchOberflaeche.Top:= 5;
-    CreateSystemInfo;
+
+    // In the normal case of tsofShowOutput
+    // we call CreateSystemInfo and show the
+    // output of the called process
+    //
+    // if tsofShowOutputNoSystemInfo is used
+    // we assume that the caller already has
+    // created a SystemInfo and just append
+    // to that one. We also won't free it and
+    // assume the caller does it.
+    if showoutputflag = tsofShowOutput then
+    begin
+       LogDatei.log('Start Showoutput', LLInfo);
+       CreateSystemInfo;
+       SystemInfo.Memo1.Lines.clear;
+    end;
+
     SystemInfo.Memo1.Color:= clBlack;
     SystemInfo.Memo1.Font.Color := clWhite;
-    SystemInfo.Memo1.Lines.clear;
     systeminfo.BitBtn1.Enabled:= false;
     systeminfo.Label1.Caption:='Executing: '+CmdLinePasStr;
     systeminfo.ShowOnTop;
     ProcessMess;
-    LogDatei.log('Start Showoutput', LLInfo);
   end;
   {$ENDIF GUI}
 
@@ -4425,11 +4449,17 @@ begin
   {$IFDEF GUI}
   if showoutput then
   begin
-    SystemInfo.free; SystemInfo := nil;
+    // if tsofShowOutputNoSystemInfo we assume
+    // the caller will free the SystemInfo for us
+    if showoutputflag = tsofShowOutput then
+    begin
+      LogDatei.log('Stop Showoutput', LLInfo);
+      SystemInfo.free;
+      SystemInfo := nil;
+    end;
     FBatchOberflaeche.BringToFront;
     FBatchOberflaeche.centerWindow;
     ProcessMess;
-    LogDatei.log('Stop Showoutput', LLInfo);
   end;
   {$ENDIF GUI}
 end;

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2439,7 +2439,7 @@ var
       tmp_buffer := '';
       BytesRead := proc.output.Read(tmp_buffer, READ_BYTES);
       {$IFDEF WINDOWS}
-      OemToAnsi(tmp_buffer, tmp_buffer);
+      OemToAnsiBuff(tmp_buffer, tmp_buffer, BytesRead);
       {$ENDIF WINDOWS}
       Buffer := Buffer + tmp_buffer;
 
@@ -2954,7 +2954,7 @@ begin
     lpBuffer := '';
     Result := ReadFile(hReadPipe, lpBuffer, READ_BYTES, BytesRead, nil);
 
-    OemToAnsi(lpBuffer, lpBuffer);
+    OemToAnsiBuff(lpBuffer, lpBuffer, BytesRead);
     Buffer := Buffer + lpBuffer;
 
     LineBreakPos := AnsiPos(#13, Buffer);

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2890,6 +2890,9 @@ begin
         WaitForProcessEndingLogflag := True;
         setLength(resultfilename, 400);
         presultfilename := PChar(resultfilename);
+
+        BytesRead := 0;
+
         //mypid := ProcessInfo.dwProcessId;
 
         //FindExecutable(PChar(filename), nil, presultfilename);
@@ -3069,6 +3072,8 @@ begin
               ProcessMess;
             end;
           end;
+
+          ProcessMess;
 
           repeat
             readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output);
@@ -3462,6 +3467,8 @@ begin
               ProcessMess;
             end;
           end;
+
+          ProcessMess;
 
           repeat
             readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output);

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -4234,6 +4234,9 @@ begin
   end;
 
   {$IFDEF GUI}
+  if not WaitForReturn then
+    showoutput := false;
+
   if showoutput then
   begin
     FBatchOberflaeche.Left:= 5;

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2929,8 +2929,8 @@ var
   BytesAvail: LongWord;
   BytesLeft: LongWord;
 begin
-  Result := PeekNamedPipe(hReadPipe, @lpBuffer, READ_BYTES, @BytesRead, @BytesAvail, @BytesLeft);
-  if BytesLeft > 0 then
+  Result := PeekNamedPipe(hReadPipe, nil, READ_BYTES, @BytesRead, @BytesAvail, @BytesLeft);
+  if BytesAvail > 0 then
   begin
     lpBuffer := '';
     Result := ReadFile(hReadPipe, lpBuffer, READ_BYTES, BytesRead, nil);

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -1796,8 +1796,10 @@ begin
       on e: Exception do
       begin
         LogDatei.log_prog('Exception in StartProcess_se: ' +
-          e.message, LLError);
+          e.message, LLDebug);
+        Report := 'Could not execute process "' + CmdLinePasStr + '"';
         exitcode := -1;
+        Result := false;
       end;
     end;
   finally
@@ -2160,8 +2162,10 @@ begin
       on e: Exception do
       begin
         LogDatei.DependentAdd('Exception in StartProcess_se_as: ' +
-          e.message, LLError);
+          e.message, LLDebug);
+        Report := 'Could not execute process "' + CmdLinePasStr + '"';
         exitcode := -1;
+        Result := false;
       end;
     end;
   finally
@@ -2678,8 +2682,10 @@ begin
       on e: Exception do
       begin
         LogDatei.DependentAdd('Exception in StartProcess_cp: ' +
-          e.message, LLError);
+          e.message, LLDebug);
+        Report := 'Could not execute process "' + CmdLinePasStr + '"';
         exitcode := -1;
+        Result := false;
       end;
     end;
   finally
@@ -3136,8 +3142,10 @@ begin
       on e: Exception do
       begin
         LogDatei.DependentAdd('Exception in StartProcess_cp_lu: ' +
-          e.message, LLError);
+          e.message, LLDebug);
+        Report := 'Could not execute process "' + CmdLinePasStr + '"';
         exitcode := -1;
+        Result := false;
       end;
     end;
   finally
@@ -3533,8 +3541,10 @@ begin
     except
       on e: Exception do
       begin
-        LogDatei.log('Exception in StartProcess_cp_el: ' + e.message, LLError);
+        LogDatei.log('Exception in StartProcess_cp_el: ' + e.message, LLDebug);
+        Report := 'Could not execute process "' + CmdLinePasStr + '"';
         exitcode := -1;
+        Result := false;
       end;
     end;
   finally
@@ -4069,8 +4079,10 @@ begin
       on e: Exception do
       begin
         LogDatei.DependentAdd('Exception in StartProcess_as: ' +
-          e.message, LLError);
+          e.message, LLDebug);
+        Report := 'Could not execute process "' + CmdLinePasStr + '"';
         exitcode := -1;
+        Result := false;
       end;
     end;
   finally

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -526,6 +526,7 @@ function isGUI: boolean;
 function CheckFileExists(const FName: string; var ErrorInfo: string): boolean;
 function CreateTextfile(const FName: string; var ErrorInfo: string): boolean;
 
+function FindInSubDirs(const dir: string; const filename: string): TStringList;
 
 function PointerAufString(Alpha: string): PChar;
 //procedure DisposeString(p: PChar);
@@ -5725,6 +5726,21 @@ begin
   end;
 end;
 
+function FindInSubDirs(const dir: string; const filename: string): TStringList;
+var
+  subdirs: TStringList;
+  i: integer;
+  fullpath: string;
+begin
+  Result := TStringList.create;
+  subdirs := FindAllDirectories(dir, false);
+  for i := 0 to (subdirs.count - 1) do
+  begin
+    fullpath := ConcatPaths([subdirs[i], filename]);
+    if FileExists(fullpath) then
+      Result.Add(fullpath);
+  end;
+end;
 
 procedure TCopyCount.Init(NumberCounted: integer);
 begin

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2605,7 +2605,7 @@ begin
               if FindWindowEx(0, 0, nil, PChar(Ident)) = 0 then
               begin
                 logdatei.log('Wait for appear Window: "' + Ident +
-                  ' not found.', LLDebug);
+                  '" not found.', LLDebug);
                 if WaitSecs = 0 then
                   running := True
                 else
@@ -2622,7 +2622,7 @@ begin
                 end;
               end
               else
-                logdatei.log('Wait for appear Window: "' + Ident + ' found.', LLDebug);
+                logdatei.log('Wait for appear Window: "' + Ident + '" found.', LLDebug);
             end
 
             else if WaitForWindowVanished and not WaitWindowStarted then
@@ -2633,7 +2633,7 @@ begin
               if FindWindowEx(0, 0, nil, PChar(Ident)) <> 0 then
               begin
                 WaitWindowStarted := True;
-                logdatei.log('Wait for vanish Window: "' + Ident + ' found.', LLDebug);
+                logdatei.log('Wait for vanish Window: "' + Ident + '" found.', LLDebug);
               end;
 
               if not WaitWindowStarted or WaitForWindowVanished then

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -4329,13 +4329,12 @@ begin
     LogDatei.log('--- Process Output ---', LLDebug);
     for i := 0 to output.count-1 do
     begin
-      {$IFDEF WINDOWS}
-      output.strings[i] := WinCPToUTF8(output.strings[i]);
-      {$ENDIF WINDOWS}
       LogDatei.log (output.strings[i], LLDebug);
     end;
     LogDatei.log('----------------------', LLDebug);
-  end;
+  end
+  else
+    LogDatei.log('No Output generated or /LetThemGo used', LLDebug);
   output.Free;
 end;
 

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2536,6 +2536,9 @@ begin
       //FpcProcess.Parameters := paramlist;
       {$ENDIF WINDOWS}
 
+      if not WaitForReturn then
+        catchout := false;
+
       if catchout then
         FpcProcess.Options := FpcProcess.Options + [poUsePipes, poStdErrToOutPut];
 
@@ -3113,6 +3116,9 @@ begin
 
       wstr := CmdLinePasStr;
 
+      if not WaitForReturn then
+        catchout := false;
+
       if not CreatePipe(hReadPipe, hWritePipe, @sa, 0) then
       begin
         Report := 'Error creating Pipe';
@@ -3133,7 +3139,7 @@ begin
       if not jwawinbase.CreateProcessAsUserW(opsiSetupAdmin_logonHandle,
         nil, PWideChar(wstr), nil, nil,
         //opsiSetupAdmin_pSecAttrib, opsiSetupAdmin_pSecAttrib,
-        True,
+        catchout,  // inherit handles if we catch output
         //CREATE_NEW_CONSOLE or CREATE_NEW_PROCESS_GROUP or CREATE_UNICODE_ENVIRONMENT,
         //CREATE_NO_WINDOW or CREATE_UNICODE_ENVIRONMENT or
         //CREATE_DEFAULT_ERROR_MODE,
@@ -3528,6 +3534,9 @@ begin
         opsiSetupAdmin_lpEnvironment := nil;
       end;
 
+      if not WaitForReturn then
+        catchout := false;
+
       if not CreatePipe(hReadPipe, hWritePipe, @sa, 0) then
       begin
         Report := 'Error creating Pipe';
@@ -3548,7 +3557,8 @@ begin
       if not jwawinbase.CreateProcessAsUser(opsiSetupAdmin_logonHandle,
         nil, PChar(CmdLinePasStr),
         //nil, nil,
-        opsiSetupAdmin_pSecAttrib, opsiSetupAdmin_pSecAttrib, True,
+        opsiSetupAdmin_pSecAttrib, opsiSetupAdmin_pSecAttrib,
+        catchout, // inherit handles only if we catch output
         //CREATE_NEW_CONSOLE or CREATE_NEW_PROCESS_GROUP or CREATE_UNICODE_ENVIRONMENT,
         CREATE_NO_WINDOW or CREATE_UNICODE_ENVIRONMENT or
         CREATE_DEFAULT_ERROR_MODE, opsiSetupAdmin_lpEnvironment,
@@ -4051,6 +4061,10 @@ begin
               begin
 *)
       // Step 4: set the startup info for the new process
+
+      if not WaitForReturn then
+        catchout := false;
+
       FillChar(sa, SizeOf(sa), 0);
       sa.nLength := sizeof(sa);
       sa.lpSecurityDescriptor := nil;
@@ -4096,7 +4110,8 @@ begin
       if not jwawinbase.CreateProcessAsUser(opsiSetupAdmin_logonHandle,
         nil, PChar(CmdLinePasStr),
         //nil, nil,
-        opsiSetupAdmin_pSecAttrib, opsiSetupAdmin_pSecAttrib, True,
+        opsiSetupAdmin_pSecAttrib, opsiSetupAdmin_pSecAttrib,
+        catchout, // inherit handes only if we catch output
         //CREATE_NEW_CONSOLE or CREATE_NEW_PROCESS_GROUP or CREATE_UNICODE_ENVIRONMENT,
         CREATE_NO_WINDOW or CREATE_UNICODE_ENVIRONMENT or NORMAL_PRIORITY_CLASS,
         opsiSetupAdmin_lpEnvironment,

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -2239,7 +2239,11 @@ var
     {$ENDIF WINDOWS}
     Buffer := Buffer + tmp_buffer;
 
+    {$IFDEF WINDOWS}
     LineBreakPos := AnsiPos(#13, Buffer);
+    {$ELSE WINDOWS}
+    LineBreakPos := Pos(#10, Buffer);
+    {$ENDIF WINDOWS}
 
     while not (LineBreakPos = 0) do
     begin
@@ -2262,7 +2266,11 @@ var
 
       Buffer := Copy(Buffer, LineBreakPos + 1, READ_BYTES);
 
+      {$IFDEF WINDOWS}
       LineBreakPos := AnsiPos(#13, Buffer);
+      {$ELSE WINDOWS}
+      LineBreakPos := Pos(#10, Buffer);
+      {$ENDIF WINDOWS}
     end;
 
     Result := BytesRead;

--- a/opsi-script/osfunc.pas
+++ b/opsi-script/osfunc.pas
@@ -57,6 +57,7 @@ uses
   Shlobj,
 {$ENDIF}
 {$IFDEF GUI}
+  graphics,
   LResources,
   LCLIntf,
   LCLProc,
@@ -477,7 +478,7 @@ function StartProcess(CmdLinePasStr: string; ShowWindowFlag: integer;
   var Report: string; var ExitCode: longint): boolean; overload;
 
 function StartProcess(CmdLinePasStr: string; ShowWindowFlag: integer;
-  WaitForReturn: boolean; WaitForWindowVanished: boolean;
+  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
   WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; RunAs: TRunas; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output: TXStringList): boolean; overload;
@@ -696,6 +697,7 @@ uses
   {$IFDEF GUI}
   osbatchgui,
   osinteractivegui,
+  osshowsysinfo,
   {$ENDIF GUI}
   osmain,
   osdefinedfunctions,
@@ -2171,7 +2173,7 @@ end;
 {$ENDIF WINDOWS}
 
 function StartProcess_cp(CmdLinePasStr: string; ShowWindowFlag: integer;
-  WaitForReturn: boolean; WaitForWindowVanished: boolean;
+  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
   WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output: TXStringList): boolean;
@@ -2217,7 +2219,7 @@ var
   i: integer; // tmp
 
   function ReadStream(var Buffer: string; var proc: TProcess;
-    var output: TXStringList): LongInt;
+    var output: TXStringList; showoutput: boolean): LongInt;
   var
     tmp_buffer: Array[0..READ_BYTES] of char;
     output_line: string='';
@@ -2240,6 +2242,13 @@ var
       output_line := WINCPToUTF8(output_line);
       {$ENDIF WINDOWS}
       output.Add(output_line);
+      {$IFDEF GUI}
+      if showoutput then
+      begin
+        SystemInfo.Memo1.Lines.Add(output_line);
+        ProcessMess;
+      end;
+      {$ENDIF GUI}
 
       // skip carriage return if present
       if (length(Buffer) > LineBreakPos) and (Buffer[LineBreakPos + 1] = #10) then
@@ -2373,7 +2382,7 @@ begin
 
             running := False;
 
-            ReadStream(Buffer, FPCProcess, output);
+            ReadStream(Buffer, FPCProcess, output, showoutput);
 
             //wait for task vanished
             {$IFDEF WINDOWS}
@@ -2654,7 +2663,7 @@ begin
 
           // read remaining output
           repeat
-            n := ReadStream(Buffer, FPCProcess, output);
+            n := ReadStream(Buffer, FPCProcess, output, showoutput);
           until n <= 0;
         end;
 
@@ -2693,7 +2702,7 @@ end;
 
 {$IFDEF WIN32}
 function ReadPipe(var Buffer: string; var hReadPipe: THandle; var BytesRead: LongWord;
-  var output: TXStringList): boolean;
+  var output: TXStringList; showoutput: boolean): boolean;
 var
   output_line: string = '';
   lpBuffer: Array[0..READ_BYTES] of char;
@@ -2714,7 +2723,15 @@ begin
     while not (LineBreakPos = 0) do
     begin
       output_line := Copy(Buffer, 1, LineBreakPos - 1);
-      output.Add(WinCPToUTF8(output_line));
+      output_line := WinCPToUTF8(output_line);
+      output.Add(output_line);
+      {$IFDEF GUI}
+      if showoutput then
+      begin
+        SystemInfo.Memo1.Lines.Add(output_line);
+        ProcessMess;
+      end;
+      {$ENDIF GUI}
 
       // skip carriage return if present
       if (length(Buffer) > LineBreakPos) and (Buffer[LineBreakPos + 1] = #10) then
@@ -2728,7 +2745,7 @@ begin
 end;
 
 function StartProcess_cp_lu(CmdLinePasStr: string; ShowWindowFlag: integer;
-  WaitForReturn: boolean; WaitForWindowVanished: boolean;
+  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
   WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output: TXStringList): boolean;
@@ -2938,7 +2955,7 @@ begin
 
             running := False;
 
-            if not (ReadPipe(Buffer, hReadPipe, BytesRead, output)) then
+            if not (ReadPipe(Buffer, hReadPipe, BytesRead, output, showoutput)) then
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
 
             //wait for task vanished
@@ -3100,7 +3117,7 @@ begin
           ProcessMess;
 
           repeat
-            readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output);
+            readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output, showoutput);
             if not readResult then
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
           until (BytesRead <= 0) or (not readResult);
@@ -3148,7 +3165,7 @@ end;
 
 
 function StartProcess_cp_el(CmdLinePasStr: string; ShowWindowFlag: integer;
-  WaitForReturn: boolean; WaitForWindowVanished: boolean;
+  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
   WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output: TXStringList): boolean;
@@ -3336,7 +3353,7 @@ begin
 
             running := False;
 
-            if not (ReadPipe(Buffer, hReadPipe, BytesRead, output)) then
+            if not (ReadPipe(Buffer, hReadPipe, BytesRead, output, showoutput)) then
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
 
             //wait for task vanished
@@ -3496,7 +3513,7 @@ begin
           ProcessMess;
 
           repeat
-            readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output);
+            readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output, showoutput);
             if not readResult then
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
           until (BytesRead <= 0) or (not readResult);
@@ -3530,7 +3547,7 @@ end;
 
 
 function StartProcess_as(CmdLinePasStr: string; ShowWindowFlag: integer;
-  WaitForReturn: boolean; WaitForWindowVanished: boolean;
+  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
   WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output: TXStringList): boolean;
@@ -3865,7 +3882,7 @@ begin
 
             running := False;
 
-            if not (ReadPipe(Buffer, hReadPipe, BytesRead, output)) then
+            if not (ReadPipe(Buffer, hReadPipe, BytesRead, output, showoutput)) then
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
 
             (* wait for task vanished *)
@@ -4033,7 +4050,7 @@ begin
           ProcessMess;
 
           repeat
-            readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output);
+            readResult := ReadPipe(Buffer, hReadPipe, BytesRead, output, showoutput);
             if not readResult then
               LogDatei.log('Read Error: ' + SysErrorMessage(getLastError()), LLError);
           until (BytesRead <= 0) or (not readResult);
@@ -4083,7 +4100,7 @@ begin
   runAs := traInvoker;
   output := TXStringList.create;
 
-  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, WaitForReturn,
+  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, false, WaitForReturn,
     WaitForWindowVanished, WaitForWindowAppearing, WaitForProcessEnding,
     runas, Ident, WaitSecs, Report, ExitCode);
 
@@ -4102,7 +4119,7 @@ begin
   // provide a temp stringlist
   output := TXStringList.create;
 
-  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, WaitForReturn,
+  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, false, WaitForReturn,
     WaitForWindowVanished, WaitForWindowAppearing, WaitForProcessEnding,
     False, runAs, Ident, WaitSecs, Report, ExitCode, output);
 
@@ -4120,7 +4137,7 @@ begin
   // compatibility with old version that had no output capturing
   output := TXStringList.create;
 
-  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, WaitForReturn, WaitForWindowVanished,
+  Result := StartProcess(CmdLinePasStr, ShowWindowFlag, false, WaitForReturn, WaitForWindowVanished,
     WaitForWindowAppearing, WaitForProcessEnding, waitsecsAsTimeout, RunAs, Ident,
     WaitSecs, Report, Exitcode, output);
 
@@ -4128,7 +4145,7 @@ begin
 end;
 
 function StartProcess(CmdLinePasStr: string; ShowWindowFlag: integer;
-  WaitForReturn: boolean; WaitForWindowVanished: boolean;
+  showoutput: boolean; WaitForReturn: boolean; WaitForWindowVanished: boolean;
   WaitForWindowAppearing: boolean; WaitForProcessEnding: boolean;
   waitsecsAsTimeout: boolean; RunAs: TRunAs; Ident: string; WaitSecs: word;
   var Report: string; var ExitCode: longint; var output : TXStringList): boolean;
@@ -4203,13 +4220,31 @@ begin
       filename := CmdLinePasStr;
     end;
   end;
+
+  {$IFDEF GUI}
+  if showoutput then
+  begin
+    FBatchOberflaeche.Left:= 5;
+    FBatchOberflaeche.Top:= 5;
+    CreateSystemInfo;
+    SystemInfo.Memo1.Color:= clBlack;
+    SystemInfo.Memo1.Font.Color := clWhite;
+    SystemInfo.Memo1.Lines.clear;
+    systeminfo.BitBtn1.Enabled:= false;
+    systeminfo.Label1.Caption:='Executing: '+CmdLinePasStr;
+    systeminfo.ShowOnTop;
+    ProcessMess;
+    LogDatei.log('Start Showoutput', LLInfo);
+  end;
+  {$ENDIF GUI}
+
   {$IFDEF UNIX}
   // we start as Invoker
   // we assume that this is a executable
   // we try it via createprocess (Tprocess)
   LogDatei.DependentAdd(
     'Start process as invoker: ' + getCommandResult('/bin/bash -c whoami'), LLInfo);
-  Result := StartProcess_cp(CmdLinePasStr, ShowWindowFlag, WaitForReturn,
+  Result := StartProcess_cp(CmdLinePasStr, ShowWindowFlag, showoutput, WaitForReturn,
     WaitForWindowVanished, WaitForWindowAppearing, WaitForProcessEnding,
     waitsecsAsTimeout, Ident, WaitSecs, Report, ExitCode, output);
   {$ENDIF LINUX}
@@ -4221,7 +4256,7 @@ begin
     // we assume that this is a call of a not executable file
     // this is deprecated so we warn and still try it via shellexecute
     logdatei.DependentAdd('winbatch call of not executable file: ' +
-      filename + ' is deprecated', LLWarning);
+      filename + ' is deprecated and output capturing not supported', LLWarning);
     Result := StartProcess_se(CmdLinePasStr, ShowWindowFlag,
       WaitForReturn, WaitForWindowVanished, WaitForWindowAppearing,
       WaitForProcessEnding, waitsecsAsTimeout, Ident, WaitSecs, Report, ExitCode);
@@ -4247,7 +4282,7 @@ begin
       // we try it via createprocess (Tprocess)
       LogDatei.log(
         'Start process as invoker: ' + DSiGetUserName, LLInfo);
-      Result := StartProcess_cp(CmdLinePasStr, ShowWindowFlag,
+      Result := StartProcess_cp(CmdLinePasStr, ShowWindowFlag, showoutput,
         WaitForReturn, WaitForWindowVanished, WaitForWindowAppearing,
         WaitForProcessEnding, waitsecsAsTimeout, Ident, WaitSecs, Report, ExitCode, output);
     end
@@ -4280,7 +4315,7 @@ begin
         LogDatei.DependentAdd(
           'Start process as LoggedOnUser: ' + usercontextDomain +
           '\' + usercontextUser, LLInfo);
-        Result := StartProcess_cp_lu(CmdLinePasStr, ShowWindowFlag,
+        Result := StartProcess_cp_lu(CmdLinePasStr, ShowWindowFlag, showoutput,
           WaitForReturn, WaitForWindowVanished, WaitForWindowAppearing,
           WaitForProcessEnding, waitsecsAsTimeout, Ident, WaitSecs, Report, ExitCode, output);
         if not Result then
@@ -4299,7 +4334,7 @@ begin
       // we assume that this is a executable
       // we try it via createprocess (Tprocess)
       LogDatei.log('Start process elevated ....', LLInfo);
-      Result := StartProcess_cp_el(CmdLinePasStr, ShowWindowFlag,
+      Result := StartProcess_cp_el(CmdLinePasStr, ShowWindowFlag, showoutput,
         WaitForReturn, WaitForWindowVanished, WaitForWindowAppearing,
         WaitForProcessEnding, waitsecsAsTimeout, Ident, WaitSecs, Report, ExitCode, output);
 
@@ -4310,7 +4345,7 @@ begin
       if opsiSetupAdmin_created then
       begin
         //it is still created
-        Result := StartProcess_as(CmdLinePasStr, ShowWindowFlag,
+        Result := StartProcess_as(CmdLinePasStr, ShowWindowFlag, showoutput,
           WaitForReturn, WaitForWindowVanished, WaitForWindowAppearing,
           WaitForProcessEnding, waitsecsAsTimeout, Ident, WaitSecs, Report, ExitCode, output);
         dwThreadId := GetCurrentThreadId;
@@ -4340,14 +4375,14 @@ begin
           begin
             Logdatei.DependentAdd('Could not create Temporary Admin ', LLError);
             Logdatei.DependentAdd('Try to run without temporary Admin ', LLWarning);
-            Result := StartProcess_cp(CmdLinePasStr, ShowWindowFlag,
+            Result := StartProcess_cp(CmdLinePasStr, ShowWindowFlag, showoutput,
               WaitForReturn, WaitForWindowVanished, WaitForWindowAppearing,
               WaitForProcessEnding, waitsecsAsTimeout, Ident, WaitSecs,
               Report, ExitCode, output);
           end
           else
           begin
-            Result := StartProcess_as(CmdLinePasStr, ShowWindowFlag,
+            Result := StartProcess_as(CmdLinePasStr, ShowWindowFlag, showoutput,
               WaitForReturn, WaitForWindowVanished, WaitForWindowAppearing,
               WaitForProcessEnding, waitsecsAsTimeout, Ident, WaitSecs,
               Report, ExitCode, output);
@@ -4371,6 +4406,17 @@ begin
     end;
   end;
   {$ENDIF WIN32}
+
+  {$IFDEF GUI}
+  if showoutput then
+  begin
+    SystemInfo.free; SystemInfo := nil;
+    FBatchOberflaeche.BringToFront;
+    FBatchOberflaeche.centerWindow;
+    ProcessMess;
+    LogDatei.log('Stop Showoutput', LLInfo);
+  end;
+  {$ENDIF GUI}
 end;
 
 

--- a/opsi-script/oslocaladmin.pas
+++ b/opsi-script/oslocaladmin.pas
@@ -73,6 +73,7 @@ const
   SID_REVISION = 1;
   FILENAME_ADVAPI32 = 'ADVAPI32.DLL';
   PROC_CONVERTSIDTOSTRINGSIDA = 'ConvertSidToStringSidA';
+  ADMIN_SIDSTRING = 'S-1-5-32-544';
 
 type
   Tadminmode = (useronly, full);
@@ -258,7 +259,7 @@ begin
       traAdminProfileImpersonateExplorer, traAdminProfileImpersonate] then
     begin
       // get localized name of administrators
-      wGroup := StrSIDToName('S-1-5-32-544');
+      wGroup := StrSIDToName(ADMIN_SIDSTRING);
       opsiSetupAdmin_Password := randomstr(True);
       mypass := opsiSetupAdmin_Password;
       Result := CreateWinUser(DSiGetComputerName, 'opsiSetupAdmin',

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10418,8 +10418,9 @@ begin
       begin
         output := TXStringlist.Create;
         LogDatei.log('Executing ' + commandline, LLDebug + logleveloffset);
-        if not RunCommandAndCaptureOut(commandline, catchout,
-          output, report, showcmd, FLastExitCodeOfExe, showoutput) then
+        if not StartProcess(commandline, showcmd, showoutput,
+          true, false, false, false, false, runAs, '', 0,
+          report, FLastExitCodeOfExe, output) then
         begin
           // is failed
           ps := 'Error: ' + IntToStr(FLastExitCodeOfExe) + ' : ' + Report;
@@ -10430,9 +10431,9 @@ begin
             LogDatei.log(ps, LLError);
             ProcessMess;
             Sleep(100);
-            if not RunCommandAndCaptureOut(commandline,
-              catchout, output, report, showcmd,
-              FLastExitCodeOfExe, showoutput) then
+            if not StartProcess(commandline, showcmd, showoutput,
+              true, false, false, false, false, runAs, '', 0,
+              report, FLastExitCodeOfExe, output) then
             begin
               LogDatei.log(ps, LLcritical);
               FExtremeErrorLevel := LevelFatal;

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -9604,6 +9604,8 @@ var
   waitsecsAsTimeout: boolean = False;
   oldDisableWow64FsRedirectionStatus: pointer = nil;
   Wow64FsRedirectionDisabled, boolresult: boolean;
+  output: TXStringList;
+  outputStart: integer=0;
 
 begin
   try
@@ -9632,6 +9634,8 @@ begin
       FBatchOberflaeche.showAcitvityBar(True);
     {$ENDIF GUI}
 
+    output := TXStringList.create;
+    outputStart := 0;
 
     for i := 1 to Sektion.Count do
     begin
@@ -9700,8 +9704,9 @@ begin
         begin
           LogDatei.log('   Waiting until window "' + ident +
             '" has vanished', LevelComplete);
-          if not StartProcess(Commandline, sw_hide, True, True,
-            False, False, waitsecsAsTimeout, runAs, ident, WaitSecs, Report, FLastExitCodeOfExe)
+          if not StartProcess(Commandline, sw_hide, true, true, false, false,
+            waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
+            FLastExitCodeOfExe, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -9715,8 +9720,9 @@ begin
           LogDatei.log('   Waiting until window "' + ident +
             '" is coming up', LevelComplete);
 
-          if not StartProcess(Commandline, sw_hide, True, False,
-            True, False, waitsecsAsTimeout, runAs, ident, WaitSecs, Report, FLastExitCodeOfExe)
+          if not StartProcess(Commandline, sw_hide, true, false, true, false,
+            waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
+            FLastExitCodeOfExe, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -9730,8 +9736,9 @@ begin
           LogDatei.log('   Waiting until process "' + ident +
             '" started and has ended', LevelComplete);
 
-          if not StartProcess(Commandline, sw_hide, True, False,
-            False, True, waitsecsAsTimeout, runAs, ident, WaitSecs, Report, FLastExitCodeOfExe)
+          if not StartProcess(Commandline, sw_hide, true, false, false, true,
+            waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
+            FLastExitCodeOfExe, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -9770,8 +9777,9 @@ from defines.inc
    SW_SHOWNORMAL = 1;
 *)
 
-          if not StartProcess(Commandline, sw_hide, WaitForReturn,
-            False, False, False, waitsecsAsTimeout, runAs, '', WaitSecs, Report, FLastExitCodeOfExe)
+          if not StartProcess (Commandline, sw_hide, WaitForReturn, false,
+            false, false, waitsecsAsTimeout, runAs, '', WaitSecs, Report,
+            FLastExitCodeOfExe, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -9779,6 +9787,20 @@ from defines.inc
           end
           else
             LogDatei.log(Report, LLInfo);
+        end;
+
+        if (outputStart < output.count) then
+        begin
+          LogDatei.LogSIndentLevel := LogDatei.LogSIndentLevel + 1;
+          LogDatei.log ('output:', LLDebug);
+          LogDatei.log ('--------------', LLDebug);
+          while outputStart < output.count do
+          begin
+            LogDatei.log(output.strings[outputStart], LLDebug);
+            Inc(outputStart, 1);
+          end;
+          LogDatei.log ('--------------', LLDebug);
+          LogDatei.LogSIndentLevel := LogDatei.LogSIndentLevel - 1;
         end;
       end;
     end;
@@ -9789,6 +9811,7 @@ from defines.inc
       Wow64FsRedirectionDisabled := False;
     end;
     {$ENDIF WIN32}
+    output.free;
     finishSection(Sektion, OldNumberOfErrors, OldNumberOfWarnings,
       DiffNumberOfErrors, DiffNumberOfWarnings);
 

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10016,7 +10016,7 @@ begin
     if force64 then
     begin
       if (not FileExists(GetWinDirectory + '\cmd64.exe')) or
-        (FindAllFiles('c:\windows', 'cmd64.exe.mui', True).Count = 0) then
+        (FindInSubDirs('c:\windows','cmd64.exe.mui').Count = 0) then
       begin
         Logdatei.log(GetWinDirectory + '\cmd64.exe not found - try to get it',
           LLDebug2 + logleveloffset);
@@ -10032,7 +10032,7 @@ begin
                 LogDatei.log('cmd64.exe created in ' + GetWinDirectory,
                   LLinfo + logleveloffset);
                 cmdMuiFiles := TStringList.Create;
-                cmdMuiFiles := FindAllFiles('c:\windows\system32', 'cmd.exe.mui', True);
+                cmdMuiFiles := FindInSubDirs('c:\windows\system32', 'cmd.exe.mui');
                 for i := 0 to cmdMuiFiles.Count - 1 do
                 begin
                   LogDatei.log('cmd.exe.mui found in ' + cmdMuiFiles.Strings[i],

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10304,7 +10304,7 @@ begin
 
       {$IFNDEF WINDOWS}
       if warnOnlyWindows then
-        LogDatei.log('Warning: at least one Windows-only Parameter was used', LLWarning);
+        LogDatei.log('Warning: at least one Windows-only Parameter was used', LLError);
       {$ENDIF WINDOWS}
 
 (*
@@ -10956,19 +10956,12 @@ begin
          begin
            onlyWindows := true;
          end;
-
-         {$IFNDEF WINDOWS}
-         if onlyWindows then
-           break;
-         {$ENDIF WINDOWS}
       end;
 
       {$IFNDEF WINDOWS}
       if onlyWindows then
       begin
-        LogDatei.log('Error: ' + '"' + expr + '" is only supported on Windows!', LLcritical);
-        FExtremeErrorLevel := LevelFatal;
-        exit;
+        LogDatei.log('Error: at least one Windows-only Parameter was used', LLError);
       end;
       {$ENDIF WINDOWS}
 

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10767,7 +10767,10 @@ begin
         // try to parse a RunAs param
         GetWord(remaining, expr, remaining, WordDelimiterWhiteSpace);
         if not RunAsForParameter(expr, tmpRunAs) then
+        begin
+          remaining := expr + ' ' + remaining;
           continue := false;
+        end;
       end;
     end;
 

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10828,7 +10828,6 @@ var
   goon : boolean;
   remaining : string;
   expr : string='';
-  SyntaxCheck: boolean;
   onlyWindows: boolean;
   showoutput: TShowOutputFlag;
   sysError: DWORD;
@@ -10925,10 +10924,9 @@ begin
           ' "' + tempfilename + '"  ' + passparas;
 
       remaining := winstoption;
-      SyntaxCheck := true;
       onlyWindows := false;
 
-      while (remaining <> '') and SyntaxCheck do
+      while (remaining <> '') do
       begin
          GetWord (remaining, expr, remaining, WordDelimiterWhiteSpace);
 
@@ -10954,28 +10952,22 @@ begin
          else if RunAsForParameter(expr, runas) then
          begin
            onlyWindows := true;
-         end
-         else
-         begin
-           SyntaxCheck := false;
-           errorInfo := '"' + expr + '" is not a valid ExecWith parameter!';
          end;
 
          {$IFNDEF WINDOWS}
          if onlyWindows then
-         begin
-           SyntaxCheck := false;
-           errorInfo := '"' + expr + '" is only supported on Windows!';
-         end;
+           break;
          {$ENDIF WINDOWS}
       end;
 
-      if not SyntaxCheck then
+      {$IFNDEF WINDOWS}
+      if onlyWindows then
       begin
-        LogDatei.log('Error: ' + errorInfo, LLcritical);
-        FExtremeErrorLevel:=LevelFatal;
+        LogDatei.log('Error: ' + '"' + expr + '" is only supported on Windows!', LLcritical);
+        FExtremeErrorLevel := LevelFatal;
         exit;
       end;
+      {$ENDIF WINDOWS}
 
       {$IFDEF WIN32}
       // allow the executing user access to the tmp file

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10951,7 +10951,7 @@ begin
          begin
            // Don't generate a syntax error to keep in line with old behavior
            SyntaxCheck := true;
-           errorInfo := '"' + expr '" is only supported on Windows!';
+           errorInfo := '"' + expr + '" is only supported on Windows!';
            LogDatei.log('Warning: ' + errorInfo, LLWarning);
          end;
          {$ENDIF WINDOWS}

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -568,7 +568,8 @@ type
       SaveddeWithProgman: boolean): TSectionResult;
     function execWinBatch(const Sektion: TWorkSection; WinBatchParameter: string;
       WaitConditions: TSetWaitConditions; ident: string;
-      WaitSecs: word; runAs: TRunAs; flag_force64: boolean): TSectionResult;
+      WaitSecs: word; runAs: TRunAs; flag_force64: boolean;
+      showoutput: boolean): TSectionResult;
     function parseAndCallWinbatch(ArbeitsSektion: TWorkSection;
       var Remaining: string; linecounter: integer): TSectionResult;
     function execDOSBatch(const Sektion: TWorkSection; BatchParameter: string;
@@ -672,6 +673,7 @@ const
   ParameterRunElevated = '/RunElevated';
   ParameterRunAsLoggedOnUser = '/RunAsLoggedOnUser';
   ParameterShowWindowHide = '/WindowHide';
+  ParameterShowoutput = '/showoutput';
 
 
   DefaultWaitProcessTimeoutSecs = 1200; //20 min
@@ -9386,6 +9388,7 @@ var
  onlyWindows : boolean;
  InfoSyntaxError : String='';
  sectionName : String='';
+ showoutput: boolean;
 
 begin
  if length(ArbeitsSektion.Name) <> 0 then
@@ -9551,6 +9554,11 @@ begin
        WaitConditions := WaitConditions + [ttpWaitOnTerminate];
    End
 
+   else if lowercase (expr) = lowercase (ParameterShowoutput) then
+   begin
+       showoutput := true;
+   end
+
    else if RunAsForParameter(expr, runas) then
    begin
      onlyWindows := true;
@@ -9578,7 +9586,8 @@ begin
 
  if SyntaxCheck
  then
-   Result := execWinBatch (ArbeitsSektion, Remaining, WaitConditions, Ident, WaitSecs, runAs,flag_force64)
+   Result := execWinBatch (ArbeitsSektion, Remaining, WaitConditions, Ident,
+     WaitSecs, runAs, flag_force64, showoutput)
  else
    Result := reportError (ArbeitsSektion, linecounter, 'Expressionstr', InfoSyntaxError);
 end;
@@ -9589,7 +9598,8 @@ function TuibInstScript.execWinBatch(const Sektion: TWorkSection;
   ident: string;
   WaitSecs: word;
   runAs: TRunAs;
-  flag_force64: boolean)
+  flag_force64: boolean;
+  showoutput: boolean)
 : TSectionResult;
 
 var
@@ -9704,8 +9714,8 @@ begin
         begin
           LogDatei.log('   Waiting until window "' + ident +
             '" has vanished', LevelComplete);
-          if not StartProcess(Commandline, sw_hide, true, true, false, false,
-            waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
+          if not StartProcess(Commandline, sw_hide, showoutput, true, true, false,
+            false, waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
             FLastExitCodeOfExe, output)
           then
           begin
@@ -9720,8 +9730,8 @@ begin
           LogDatei.log('   Waiting until window "' + ident +
             '" is coming up', LevelComplete);
 
-          if not StartProcess(Commandline, sw_hide, true, false, true, false,
-            waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
+          if not StartProcess(Commandline, sw_hide, showoutput, true, false, true,
+            false, waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
             FLastExitCodeOfExe, output)
           then
           begin
@@ -9736,8 +9746,8 @@ begin
           LogDatei.log('   Waiting until process "' + ident +
             '" started and has ended', LevelComplete);
 
-          if not StartProcess(Commandline, sw_hide, true, false, false, true,
-            waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
+          if not StartProcess(Commandline, sw_hide, showoutput, true, false, false,
+            true, waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
             FLastExitCodeOfExe, output)
           then
           begin
@@ -9777,8 +9787,8 @@ from defines.inc
    SW_SHOWNORMAL = 1;
 *)
 
-          if not StartProcess (Commandline, sw_hide, WaitForReturn, false,
-            false, false, waitsecsAsTimeout, runAs, '', WaitSecs, Report,
+          if not StartProcess (Commandline, sw_hide, showoutput, WaitForReturn,
+            false, false, false, waitsecsAsTimeout, runAs, '', WaitSecs, Report,
             FLastExitCodeOfExe, output)
           then
           begin

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10995,7 +10995,7 @@ begin
       LogDatei.log_prog ('Executing ' + commandline, LLDebug);
       if not StartProcess(Commandline, showcmd, showoutput, not threaded,
         false, false, false, false, runas, '', WaitSecs, Report,
-        FLastExitCodeOfExe, true, output)
+        FLastExitCodeOfExe, catchout, output)
       then
       begin
         ps := 'Error: ' + Report;

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -9413,6 +9413,7 @@ begin
  GetWord (Remaining, expr, Remaining, WordDelimiterSet0);
  SyntaxCheck := true;
  onlyWindows := false;
+ showoutput := false;
 
  ident := '';
  WaitConditions := [ttpWaitOnTerminate];

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -9747,7 +9747,7 @@ begin
             '" has vanished', LevelComplete);
           if not StartProcess(Commandline, sw_hide, showoutputFlag, true, true,
             false, false, waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
-            FLastExitCodeOfExe, output)
+            FLastExitCodeOfExe, true, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -9763,7 +9763,7 @@ begin
 
           if not StartProcess(Commandline, sw_hide, showoutputFlag, true, false,
             true, false, waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
-            FLastExitCodeOfExe, output)
+            FLastExitCodeOfExe, true, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -9779,7 +9779,7 @@ begin
 
           if not StartProcess(Commandline, sw_hide, showoutputFlag, true, false,
             false, true, waitsecsAsTimeout, runAs, ident, WaitSecs, Report,
-            FLastExitCodeOfExe, output)
+            FLastExitCodeOfExe, true, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -9813,7 +9813,7 @@ from defines.inc
 
           if not StartProcess (Commandline, sw_hide, showoutputFlag,
             WaitForReturn, false, false, false, waitsecsAsTimeout, runAs, '',
-            WaitSecs, Report, FLastExitCodeOfExe, output)
+            WaitSecs, Report, FLastExitCodeOfExe, true, output)
           then
           begin
             ps := 'Error: ' + Report;
@@ -10465,7 +10465,7 @@ begin
         LogDatei.log('Executing ' + commandline, LLDebug + logleveloffset);
         if not StartProcess(commandline, showcmd, showoutput,
           true, false, false, false, false, runAs, '', 0,
-          report, FLastExitCodeOfExe, output) then
+          report, FLastExitCodeOfExe, catchout, output) then
         begin
           // is failed
           ps := 'Error: ' + IntToStr(FLastExitCodeOfExe) + ' : ' + Report;
@@ -10478,7 +10478,7 @@ begin
             Sleep(100);
             if not StartProcess(commandline, showcmd, showoutput,
               true, false, false, false, false, runAs, '', 0,
-              report, FLastExitCodeOfExe, output) then
+              report, FLastExitCodeOfExe, catchout, output) then
             begin
               LogDatei.log(ps, LLcritical);
               FExtremeErrorLevel := LevelFatal;
@@ -10995,7 +10995,7 @@ begin
       LogDatei.log_prog ('Executing ' + commandline, LLDebug);
       if not StartProcess(Commandline, showcmd, showoutput, not threaded,
         false, false, false, false, runas, '', WaitSecs, Report,
-        FLastExitCodeOfExe, output)
+        FLastExitCodeOfExe, true, output)
       then
       begin
         ps := 'Error: ' + Report;

--- a/opsi-script/osparser.pas
+++ b/opsi-script/osparser.pas
@@ -10762,7 +10762,8 @@ begin
         not Skip(ParameterEscapeStrings, remaining, remaining, InfoSyntaxError) and
         not Skip(Parameter_64Bit, remaining, remaining, InfoSyntaxError) and
         not Skip(Parameter_32Bit, remaining, remaining, InfoSyntaxError) and
-        not Skip(Parameter_SysNative, remaining, remaining, InfoSyntaxError) then
+        not Skip(Parameter_SysNative, remaining, remaining, InfoSyntaxError) and
+        not Skip(ParameterShowOutput, remaining, remaining, InfoSyntaxError) then
       begin
         // try to parse a RunAs param
         GetWord(remaining, expr, remaining, WordDelimiterWhiteSpace);


### PR DESCRIPTION
## Motivation

The original motivation for this pull-request was to allow DosBatch-Sections to be executed with elevated privileges like WinBatch could be using `/RunElevated`. This change also has been [suggested in the OPSI forum](https://forum.opsi.org/viewtopic.php?f=5&t=8293&p=37679).

While implementing these changes it was apparent that the following desireable changes would also be easy to implement given the already necessary changes:

* `/Run*`-Parameters for `ExecWith`
* Output catching, `/showouput` and `getOutStreamFromSection` support for `WinBatch` ([these features have also - more or less - been asked for on the forum](https://forum.opsi.org/viewtopic.php?f=7&t=11500))

Having `/Run*` for `ExecWith` and `DosBatch` is great because it allows to use these more convenient sections in almost every case instead of `WinBatch` which is usually less convenient and harder to debug. I wished for this feature especially when working with PowerShell and Batch from OPSI.

The hard to debug problem also gets better with this pull request. Since `WinBatch` now supports catching its output, it is also logged and can be used for debugging.

## Implementation Approach

The basic idea for the implementation was to use `StartProcess` for all process execution, since it already implements executing processes with different levels of privilege, which seemed to be the most complicated task at hand. Since `StartProcess` lacked the feature to capture output, it was necessary to add that.

Then we could switch `ExecWith` and `DosBatch` to `StartProcess`, replacing `RunCommandAndCaptureOut`. Additionally it was possible to add output logging and display to `WinBatch`.

## Changes

* Fix build errors on Linux
* `osfunc` 
  * `StartProcess`
    * Generate a negative `Result` and a corresponding `Report` if an Exception occurs.
    * Accept a `TXStringList` as Parameter to which the output of the started process is written. Supported by `StartProcess_cp`, `StartProcess_cp_lu`, `StartProcess_cp_el` and `StartProcess_as`. Currently not supported by `StartProcess_se` (deprecated) and `StartProcess_se_as` (unused anyways).
    * Added a `showoutputflag` parameter which works like the `showouput` parameter of `RunCommandAndCaptureOut`, but also allows the calling function to handle creating and freeing the used `SystemInfo` (which is relevant for `WinBatch`). This is supported by all process starting types that also support output catching.
    * Allow inherting handles from the caller to the started process in `CreateProcess` for `StartProcess_cp_as`, `StartProcess_cp_el` and `StartProcess_cp_lu` (necessary for output capturing).
    * Allow output catching to be enabled and disabled with a `catchout` parameter.
  * `TShowOutputFlag`: new enum type used for `StartProcess`.
  * `SetFilePermissionForRunAs`: new function that adds an ACL entry to a given file to make it readable and executable for a given `TRunAs`-Level. It operates like this:
    * `traInvoker` (and RunElevated): no ACL entry required, ignore
    * `traLoggedOnUser`: use `usercontextSID` for ACL entry
    * `traAdmin` etc.: create temporary admin and then add ACL entry for `opsiSetupAdmin`
    * `traPcpatch`: fail with an error message, since it is not intended to be used with `traPcpatch`
* `osparser`
  * Reduce code duplication
    * move parsing of `/Run*`-Parameters to a central function, `RunAsForParameter`
    * move `parseAndCallWinBatch` to the top level and use it for parsing parameters of `processCall` as well
  * `DosBatch`
     * Use `StartProcess` exclusively instead of `RunCommandAndCaptureOut`
     * Log an error if an windows-only parameter has been used on macOS or Linux
     * Support all `/Run*`-Parameters that `WinBatch` has.
     * Call `SetFilePermissionForRunAs` after creating the temporary file to ensure the script can be executed, if the runas-level has less privileges than `SYSTEM` (e. g. `/RunAsLoggedOnAdmin` or `/RunAsLoggedOnUser`).
  * `WinBatch` / `processCall`
    * Return more a specific error message when an Windows-only parameter has been used on a non-Windows platform.
    * Log process output unless `/LetThemGo` was used.
    * Support displaying process output in `SystemInfo` window using `/showoutput`
  * `ExecWith`
    * Use `StartProcess` exclusively instead of `RunCommandAndCaptureOut`
    * Support all `/Run*`-Parameters that `WinBatch` has.
    * Call `SetFilePermissionForRunAs` after creating the temporary file to ensure the script can be executed
    * Add `/showoutput` parameter
    * Detect if an option is not supported on the current platform and log as an error, but continue executing.
  * `getOutStreamFromSection`: support `WinBatch` (note that the `StringList` will be empty if `/LetThemGo` was used)
  * `shellCall`: improve startup performance by only searching for `cmd64.exe.mui` in direct subdirs of  `C:\windows` instead of all of them recursively. This gets rid of some constant initial delay after calling `shellCall` and fixes a test (`processCall /WaitForWindowAppearing`) of `opsi-script-test` being marked as failed erroneously. 

For reviewing the code, I'd recommend go through the diffs commit by commit, I tried to group the changes into commits that make sense.

## Testing

I tested using custom opsi scripts for the specific new features and opsi-script-test in the following versions:

- [x] `opsi-script-test` from `stable` (4.12.1.5-1) on Windows
- [x] [fixed `opsi-script-test`](https://github.com/opsi-org/opsi-script-test/pull/1) from `experimental` (modified 4.12.3.9-2, fixed a bug in Winbatch tests) on Windows  
- [x] [fixed `opsi-script-test`](https://github.com/opsi-org/opsi-script-test/pull/2)  from `experimental` (modified 4.12.3.9-2, fixed a bug in `sleepSeconds` test) on Linux
- [x] [fixed `opsi-script-test` login script](https://github.com/opsi-org/opsi-script-test/pull/3) from `experimental` (modified 4.12.3.9-2, fixed a bug in `/RunAsLoggedOnUser` test) on Windows

## Open Questions

* Code Style / Implementation: I'm no regular Free Pascal Developer by any means, so I'd love to hear feedback on my code and areas to improve. Also I'm not sure if the code itself is self-explanatory and documented enough.
* Documentation: The changed usage should be documented in the opsi script manual. I'd propose I prepare a Pull Request for the documentation repository ~~in the next weeks~~.
* ~~More thorough testing: I tested mostly using simple OPSI scripts and different parameter combinations both on Linux and on running Windows OPSI Setups. Not sure if this could be improved.~~
* Performance: Checking every second, wether the process is still there, then reading a small amount of text and then waiting again could probably be improved for a smoother experience, especially when using `/showoutput`.
* I mostly use the `...A` version of WinApi functions. From my reckoning this should be no problem in all cases, but I'm not 100% sure, so I'd love feedback on that.

## Further Improvements

These are further improvements which came to mind while developing this. I might investigate them further in the future and submit additional pull requests. I'm not sure yet if they're worth implementing, so I'm looking for feedback on those, especially concerning `StartProcess_se` and logging.

* Add log level offset support for `StartProcess` and make log output more consistent with previous version overall for `DosBatch` and `ExecWith`. Log indentation is additionally kind of funky on GNU/Linux as well, although it was this way before.
* Switch `ExecPython` to `StartProcess`, add support for `/Run*` and `/showoutput` parameters. I haven't done this until now, because it requires adding section options to `ExecPython` by using a `winst` keyword or similar. This would also be possible for `powershellCall` and `shellCall`.
* Switch from `TProcess.CommandLine` which is deprecated to `TProcess.Executable` and `TProcess.Parameters`. This would probably require implementing something similar to `/EscapeStrings` for `WinBatch` and reworking the parameters of `StartProcess`.
* Implement Output Catching for `StartProcess_se` (and `StartProcess_se_as`). I didn't bother until now because the function is deprecated anyway.
* Add `processCall_list` variant of `processCall` which returns its output as `StringList`

## Conclusion

I'm looking forward to hearing from you on this pull request. I think it is a great change which would make packaging and debugging more convenient in many cases.

I'd also be happy to make adjustments to my code if you have any suggestions or feedback.