### PR TITLE
Fix build errors on experimental concerning GNU/Linux

### DIFF
--- a/opsi-script/opsiscript.lpi
+++ b/opsi-script/opsiscript.lpi
@@ -68,8 +68,7 @@
             <CompilerMessages>
               <IgnoredMessages idx5058="True" idx5027="True"/>
             </CompilerMessages>
-            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSDEBUG
--dSYNAPSE"/>
+            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSDEBUG -dSYNAPSE"/>
           </Other>
         </CompilerOptions>
       </Item2>
@@ -112,8 +111,7 @@
             <CompilerMessages>
               <IgnoredMessages idx5058="True" idx5027="True"/>
             </CompilerMessages>
-            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI
--dSYNAPSE"/>
+            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dSYNAPSE"/>
           </Other>
         </CompilerOptions>
       </Item3>
@@ -346,7 +344,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
-      <OtherUnitFiles Value="..\common;..\external_libraries\dcpcrypt\Ciphers;..\external_libraries\dcpcrypt\Hashes;..\external_libraries\synapse40lib;..\external_libraries\misc;..\external_libraries\uSMBIOS;..\external_libraries\dcpcrypt;..\external_libraries\indy\Lib\System;..\external_libraries\indy\Lib\Core;..\external_libraries\indy\Lib\Protocols;..\external_libraries\indy\Lib"/>
+      <OtherUnitFiles Value="..\common;..\external_libraries\dcpcrypt\Ciphers;..\external_libraries\dcpcrypt\Hashes;..\external_libraries\synapse;..\external_libraries\misc;..\external_libraries\uSMBIOS;..\external_libraries\dcpcrypt;..\external_libraries\indy\Lib\System;..\external_libraries\indy\Lib\Core;..\external_libraries\indy\Lib\Protocols;..\external_libraries\indy\Lib"/>
     </SearchPaths>
     <Parsing>
       <SyntaxOptions>
@@ -376,8 +374,7 @@
       <CompilerMessages>
         <IgnoredMessages idx5058="True" idx5027="True"/>
       </CompilerMessages>
-      <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSLOG
--dSYNAPSE"/>
+      <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSLOG -dSYNAPSE"/>
     </Other>
   </CompilerOptions>
   <Debugging>


### PR DESCRIPTION
When checking out the latest developments on `experimental` I noticed that the build fails on both GNU/Linux and Windows. I fixed this using the following changes:

* ~~Added `ostxstringlist` as used unit in units that were missing it (all windows-only units)~~
* ~~Fixed issue that `GetExitCodeProcess` would refuse to use anything but a `DWORD` by wrapping it in a second function in `StartProcess_cp`~~
* ~~Made `which()` unavailable on Windows since there is no implementation for this function on Windows currently. Adjusted `changelog.txt` accordingly.~~
* ~~Only use `TStringList` in `osregistry`, since otherwise the new unit `ostxstringlist`, that would be necessary, would cause a circular dependency.~~
* Fix path to `synapse` in `opsiscript.lpi` on GNU/Linux.
* ~~Add unit `osprocesses` to use section of `osfunclin` in order to make `which()` available.~~

With these changes `opsi-script` compiles fine both on Windows and GNU/Linux. Also I tested `opsi-script-test` on Windows, which succeeds without errors.