### PR TITLE
Fix synapse path for opsiscript.lpi

### DIFF
--- a/opsi-script/opsiscript.lpi
+++ b/opsi-script/opsiscript.lpi
@@ -68,8 +68,7 @@
             <CompilerMessages>
               <IgnoredMessages idx5058="True" idx5027="True"/>
             </CompilerMessages>
-            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSDEBUG
--dSYNAPSE"/>
+            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSDEBUG -dSYNAPSE"/>
           </Other>
         </CompilerOptions>
       </Item2>
@@ -112,8 +111,7 @@
             <CompilerMessages>
               <IgnoredMessages idx5058="True" idx5027="True"/>
             </CompilerMessages>
-            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI
--dSYNAPSE"/>
+            <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dSYNAPSE"/>
           </Other>
         </CompilerOptions>
       </Item3>
@@ -346,7 +344,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
-      <OtherUnitFiles Value="..\common;..\external_libraries\dcpcrypt\Ciphers;..\external_libraries\dcpcrypt\Hashes;..\external_libraries\synapse40lib;..\external_libraries\misc;..\external_libraries\uSMBIOS;..\external_libraries\dcpcrypt;..\external_libraries\indy\Lib\System;..\external_libraries\indy\Lib\Core;..\external_libraries\indy\Lib\Protocols;..\external_libraries\indy\Lib"/>
+      <OtherUnitFiles Value="..\common;..\external_libraries\dcpcrypt\Ciphers;..\external_libraries\dcpcrypt\Hashes;..\external_libraries\synapse;..\external_libraries\misc;..\external_libraries\uSMBIOS;..\external_libraries\dcpcrypt;..\external_libraries\indy\Lib\System;..\external_libraries\indy\Lib\Core;..\external_libraries\indy\Lib\Protocols;..\external_libraries\indy\Lib"/>
     </SearchPaths>
     <Parsing>
       <SyntaxOptions>
@@ -376,8 +374,7 @@
       <CompilerMessages>
         <IgnoredMessages idx5058="True" idx5027="True"/>
       </CompilerMessages>
-      <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSLOG
--dSYNAPSE"/>
+      <CustomOptions Value="-dOPSIWINST -dOPSISCRIPT -dGUI -dOSLOG -dSYNAPSE"/>
     </Other>
   </CompilerOptions>
   <Debugging>


### PR DESCRIPTION
On GNU/Linux the path to synapse is wrong in one case in `opsiscript.lpi`, breaking the build. This issue is not present in `opsiscriptnogui.lpi`, so I used the same paths also in `opsiscript.lpi`.